### PR TITLE
Suppress progress output if redirected

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 CC			= $(shell head -n 1 conf-cc)
 LD			= $(shell head -n 1 conf-ld)
 
-SOURCES		= memtester.c tests.c
+SOURCES		= memtester.c tests.c output.c
 OBJECTS		= $(SOURCES:.c=.o)
 HEADERS		= memtester.h
 TARGETS     = *.o compile load auto-ccld.sh find-systype make-compile make-load systype extra-libs
@@ -76,7 +76,7 @@ clean:
 
 memtester: \
 $(OBJECTS) memtester.c tests.h tests.c tests.h conf-cc Makefile load extra-libs
-	./load memtester tests.o `cat extra-libs`
+	./load memtester tests.o output.o `cat extra-libs`
 
 memtester.o: memtester.c tests.h conf-cc Makefile compile
 	./compile memtester.c

--- a/memtester.c
+++ b/memtester.c
@@ -49,7 +49,7 @@ struct test tests[] = {
     { "Bit Flip", test_bitflip_comparison },
     { "Walking Ones", test_walkbits1_comparison },
     { "Walking Zeroes", test_walkbits0_comparison },
-#ifdef TEST_NARROW_WRITES    
+#ifdef TEST_NARROW_WRITES
     { "8-bit Writes", test_8bit_wide_random },
     { "16-bit Writes", test_16bit_wide_random },
 #endif
@@ -135,7 +135,7 @@ int main(int argc, char **argv) {
     pagesize = memtester_pagesize();
     pagesizemask = (ptrdiff_t) ~(pagesize - 1);
     printf("pagesizemask is 0x%tx\n", pagesizemask);
-    
+
     /* If MEMTESTER_TEST_MASK is set, we use its value as a mask of which
        tests we run.
      */
@@ -143,7 +143,7 @@ int main(int argc, char **argv) {
         errno = 0;
         testmask = strtoul(env_testmask, 0, 0);
         if (errno) {
-            fprintf(stderr, "error parsing MEMTESTER_TEST_MASK %s: %s\n", 
+            fprintf(stderr, "error parsing MEMTESTER_TEST_MASK %s: %s\n",
                     env_testmask, strerror(errno));
             usage(argv[0]); /* doesn't return */
         }
@@ -179,12 +179,12 @@ int main(int argc, char **argv) {
                 break;
             case 'd':
                 if (stat(optarg,&statbuf)) {
-                    fprintf(stderr, "can not use %s as device: %s\n", optarg, 
+                    fprintf(stderr, "can not use %s as device: %s\n", optarg,
                             strerror(errno));
                     usage(argv[0]); /* doesn't return */
                 } else {
                     if (!S_ISCHR(statbuf.st_mode)) {
-                        fprintf(stderr, "can not mmap non-char device %s\n", 
+                        fprintf(stderr, "can not mmap non-char device %s\n",
                                 optarg);
                         usage(argv[0]); /* doesn't return */
                     } else {
@@ -192,18 +192,18 @@ int main(int argc, char **argv) {
                         device_specified = 1;
                     }
                 }
-                break;              
+                break;
             default: /* '?' */
                 usage(argv[0]); /* doesn't return */
         }
     }
 
     if (device_specified && !use_phys) {
-        fprintf(stderr, 
+        fprintf(stderr,
                 "for mem device, physaddrbase (-p) must be specified\n");
         usage(argv[0]); /* doesn't return */
     }
-    
+
     if (optind >= argc) {
         fprintf(stderr, "need memory argument, in MB\n");
         usage(argv[0]); /* doesn't return */

--- a/memtester.c
+++ b/memtester.c
@@ -28,6 +28,7 @@
 #include "types.h"
 #include "sizes.h"
 #include "tests.h"
+#include "output.h"
 
 #define EXIT_FAIL_NONSTARTER    0x01
 #define EXIT_FAIL_ADDRESSLINES  0x02
@@ -126,6 +127,8 @@ int main(int argc, char **argv) {
     int device_specified = 0;
     char *env_testmask = 0;
     ul testmask = 0;
+
+    out_initialize();
 
     printf("memtester version " __version__ " (%d-bit)\n", UL_LEN);
     printf("Copyright (C) 2001-2020 Charles Cazabon.\n");
@@ -399,6 +402,7 @@ int main(int argc, char **argv) {
                 continue;
             }
             printf("  %-20s: ", tests[i].name);
+            fflush(stdout);
             if (!tests[i].fp(bufa, bufb, count)) {
                 printf("ok\n");
             } else {

--- a/memtester.h
+++ b/memtester.h
@@ -19,4 +19,3 @@
 
 extern int use_phys;
 extern off_t physaddrbase;
-

--- a/output.c
+++ b/output.c
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Copyright (C) 2022 Luca Ceresoli <luca@lucaceresoli.net>
+ *
+ * Output routines to conditionally show testing status.
+ *
+ * out_initialize() must be called at program startup and disabled status
+ * output if stdout is not a tty. The other functions print test progress,
+ * but only if on a tty.
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+
+#include "output.h"
+
+static int show_progress = 1;
+static int wheel_pos;
+
+void out_initialize()
+{
+    show_progress = isatty(STDOUT_FILENO);
+}
+
+void out_test_start()
+{
+    if (show_progress) {
+        printf("           ");
+        fflush(stdout);
+    }
+}
+
+void out_test_setting(unsigned int j)
+{
+    if (show_progress) {
+        printf("\b\b\b\b\b\b\b\b\b\b\b");
+        printf("setting %3u", j);
+        fflush(stdout);
+    }
+}
+
+void out_test_testing(unsigned int j)
+{
+    if (show_progress) {
+        printf("\b\b\b\b\b\b\b\b\b\b\b");
+        printf("testing %3u", j);
+        fflush(stdout);
+    }
+}
+
+void out_test_end()
+{
+    if (show_progress) {
+        printf("\b\b\b\b\b\b\b\b\b\b\b           \b\b\b\b\b\b\b\b\b\b\b");
+        fflush(stdout);
+    }
+}
+
+void out_wheel_start()
+{
+    if (show_progress) {
+        putchar(' ');
+        fflush(stdout);
+        wheel_pos = 0;
+    }
+}
+
+void out_wheel_advance(unsigned int i)
+{
+    static const unsigned int wheel_often = 2500;
+    static const unsigned int n_chars = 4;
+    char wheel_char[4] = {'-', '\\', '|', '/'};
+
+    if (show_progress) {
+        if (!(i % wheel_often)) {
+            putchar('\b');
+            putchar(wheel_char[++wheel_pos % n_chars]);
+            fflush(stdout);
+        }
+    }
+}
+
+void out_wheel_end()
+{
+    if (show_progress) {
+        printf("\b \b");
+        fflush(stdout);
+    }
+}

--- a/output.h
+++ b/output.h
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Copyright (C) 2022 Luca Ceresoli <luca@lucaceresoli.net>
+ *
+ * Output routines to conditionally show testing status.
+ */
+
+#ifndef _OUTPUT_H_
+#define _OUTPUT_H_
+
+void out_initialize();
+
+void out_test_start();
+void out_test_setting();
+void out_test_testing();
+void out_test_end();
+
+void out_wheel_start();
+void out_wheel_advance();
+void out_wheel_end();
+
+#endif // _OUTPUT_H_

--- a/sizes.h
+++ b/sizes.h
@@ -34,5 +34,3 @@
 #else
     #error long on this platform is not 32 or 64 bits
 #endif
-
-

--- a/tests.c
+++ b/tests.c
@@ -50,13 +50,13 @@ int compare_regions(ulv *bufa, ulv *bufb, size_t count) {
         if (*p1 != *p2) {
             if (use_phys) {
                 physaddr = physaddrbase + (i * sizeof(ul));
-                fprintf(stderr, 
+                fprintf(stderr,
                         "FAILURE: 0x%08lx != 0x%08lx at physical address "
-                        "0x%08lx.\n", 
+                        "0x%08lx.\n",
                         (ul) *p1, (ul) *p2, physaddr);
             } else {
-                fprintf(stderr, 
-                        "FAILURE: 0x%08lx != 0x%08lx at offset 0x%08lx.\n", 
+                fprintf(stderr,
+                        "FAILURE: 0x%08lx != 0x%08lx at offset 0x%08lx.\n",
                         (ul) *p1, (ul) *p2, (ul) (i * sizeof(ul)));
             }
             /* printf("Skipping to next test..."); */
@@ -91,14 +91,14 @@ int test_stuck_address(ulv *bufa, size_t count) {
             if (*p1 != (((j + i) % 2) == 0 ? (ul) p1 : ~((ul) p1))) {
                 if (use_phys) {
                     physaddr = physaddrbase + (i * sizeof(ul));
-                    fprintf(stderr, 
+                    fprintf(stderr,
                             "FAILURE: possible bad address line at physical "
-                            "address 0x%08lx.\n", 
+                            "address 0x%08lx.\n",
                             physaddr);
                 } else {
-                    fprintf(stderr, 
+                    fprintf(stderr,
                             "FAILURE: possible bad address line at offset "
-                            "0x%08lx.\n", 
+                            "0x%08lx.\n",
                             (ul) (i * sizeof(ul)));
                 }
                 printf("Skipping to next test...\n");
@@ -456,7 +456,7 @@ int test_bitflip_comparison(ulv *bufa, ulv *bufb, size_t count) {
     return 0;
 }
 
-#ifdef TEST_NARROW_WRITES    
+#ifdef TEST_NARROW_WRITES
 int test_8bit_wide_random(ulv* bufa, ulv* bufb, size_t count) {
     u8v *p1, *t;
     ulv *p2;

--- a/tests.c
+++ b/tests.c
@@ -21,10 +21,8 @@
 #include "types.h"
 #include "sizes.h"
 #include "memtester.h"
+#include "output.h"
 
-char progress[] = "-\\|/";
-#define PROGRESSLEN 4
-#define PROGRESSOFTEN 2500
 #define ONE 0x00000001L
 
 union {
@@ -72,20 +70,15 @@ int test_stuck_address(ulv *bufa, size_t count) {
     size_t i;
     off_t physaddr;
 
-    printf("           ");
-    fflush(stdout);
+    out_test_start();
     for (j = 0; j < 16; j++) {
-        printf("\b\b\b\b\b\b\b\b\b\b\b");
         p1 = (ulv *) bufa;
-        printf("setting %3u", j);
-        fflush(stdout);
+        out_test_setting(j);
         for (i = 0; i < count; i++) {
             *p1 = ((j + i) % 2) == 0 ? (ul) p1 : ~((ul) p1);
             *p1++;
         }
-        printf("\b\b\b\b\b\b\b\b\b\b\b");
-        printf("testing %3u", j);
-        fflush(stdout);
+        out_test_testing(j);
         p1 = (ulv *) bufa;
         for (i = 0; i < count; i++, p1++) {
             if (*p1 != (((j + i) % 2) == 0 ? (ul) p1 : ~((ul) p1))) {
@@ -107,29 +100,21 @@ int test_stuck_address(ulv *bufa, size_t count) {
             }
         }
     }
-    printf("\b\b\b\b\b\b\b\b\b\b\b           \b\b\b\b\b\b\b\b\b\b\b");
-    fflush(stdout);
+    out_test_end();
     return 0;
 }
 
 int test_random_value(ulv *bufa, ulv *bufb, size_t count) {
     ulv *p1 = bufa;
     ulv *p2 = bufb;
-    ul j = 0;
     size_t i;
 
-    putchar(' ');
-    fflush(stdout);
+    out_wheel_start();
     for (i = 0; i < count; i++) {
         *p1++ = *p2++ = rand_ul();
-        if (!(i % PROGRESSOFTEN)) {
-            putchar('\b');
-            putchar(progress[++j % PROGRESSLEN]);
-            fflush(stdout);
-        }
+        out_wheel_advance(i);
     }
-    printf("\b \b");
-    fflush(stdout);
+    out_wheel_end();
     return compare_regions(bufa, bufb, count);
 }
 
@@ -233,27 +218,21 @@ int test_solidbits_comparison(ulv *bufa, ulv *bufb, size_t count) {
     ul q;
     size_t i;
 
-    printf("           ");
-    fflush(stdout);
+    out_test_start();
     for (j = 0; j < 64; j++) {
-        printf("\b\b\b\b\b\b\b\b\b\b\b");
         q = (j % 2) == 0 ? UL_ONEBITS : 0;
-        printf("setting %3u", j);
-        fflush(stdout);
+        out_test_setting(j);
         p1 = (ulv *) bufa;
         p2 = (ulv *) bufb;
         for (i = 0; i < count; i++) {
             *p1++ = *p2++ = (i % 2) == 0 ? q : ~q;
         }
-        printf("\b\b\b\b\b\b\b\b\b\b\b");
-        printf("testing %3u", j);
-        fflush(stdout);
+        out_test_testing(j);
         if (compare_regions(bufa, bufb, count)) {
             return -1;
         }
     }
-    printf("\b\b\b\b\b\b\b\b\b\b\b           \b\b\b\b\b\b\b\b\b\b\b");
-    fflush(stdout);
+    out_test_end();
     return 0;
 }
 
@@ -264,27 +243,21 @@ int test_checkerboard_comparison(ulv *bufa, ulv *bufb, size_t count) {
     ul q;
     size_t i;
 
-    printf("           ");
-    fflush(stdout);
+    out_test_start();
     for (j = 0; j < 64; j++) {
-        printf("\b\b\b\b\b\b\b\b\b\b\b");
         q = (j % 2) == 0 ? CHECKERBOARD1 : CHECKERBOARD2;
-        printf("setting %3u", j);
-        fflush(stdout);
+        out_test_setting(j);
         p1 = (ulv *) bufa;
         p2 = (ulv *) bufb;
         for (i = 0; i < count; i++) {
             *p1++ = *p2++ = (i % 2) == 0 ? q : ~q;
         }
-        printf("\b\b\b\b\b\b\b\b\b\b\b");
-        printf("testing %3u", j);
-        fflush(stdout);
+        out_test_testing(j);
         if (compare_regions(bufa, bufb, count)) {
             return -1;
         }
     }
-    printf("\b\b\b\b\b\b\b\b\b\b\b           \b\b\b\b\b\b\b\b\b\b\b");
-    fflush(stdout);
+    out_test_end();
     return 0;
 }
 
@@ -294,26 +267,20 @@ int test_blockseq_comparison(ulv *bufa, ulv *bufb, size_t count) {
     unsigned int j;
     size_t i;
 
-    printf("           ");
-    fflush(stdout);
+    out_test_start();
     for (j = 0; j < 256; j++) {
-        printf("\b\b\b\b\b\b\b\b\b\b\b");
         p1 = (ulv *) bufa;
         p2 = (ulv *) bufb;
-        printf("setting %3u", j);
-        fflush(stdout);
+        out_test_setting(j);
         for (i = 0; i < count; i++) {
             *p1++ = *p2++ = (ul) UL_BYTE(j);
         }
-        printf("\b\b\b\b\b\b\b\b\b\b\b");
-        printf("testing %3u", j);
-        fflush(stdout);
+        out_test_testing(j);
         if (compare_regions(bufa, bufb, count)) {
             return -1;
         }
     }
-    printf("\b\b\b\b\b\b\b\b\b\b\b           \b\b\b\b\b\b\b\b\b\b\b");
-    fflush(stdout);
+    out_test_end();
     return 0;
 }
 
@@ -323,14 +290,11 @@ int test_walkbits0_comparison(ulv *bufa, ulv *bufb, size_t count) {
     unsigned int j;
     size_t i;
 
-    printf("           ");
-    fflush(stdout);
+    out_test_start();
     for (j = 0; j < UL_LEN * 2; j++) {
-        printf("\b\b\b\b\b\b\b\b\b\b\b");
         p1 = (ulv *) bufa;
         p2 = (ulv *) bufb;
-        printf("setting %3u", j);
-        fflush(stdout);
+        out_test_setting(j);
         for (i = 0; i < count; i++) {
             if (j < UL_LEN) { /* Walk it up. */
                 *p1++ = *p2++ = ONE << j;
@@ -338,15 +302,12 @@ int test_walkbits0_comparison(ulv *bufa, ulv *bufb, size_t count) {
                 *p1++ = *p2++ = ONE << (UL_LEN * 2 - j - 1);
             }
         }
-        printf("\b\b\b\b\b\b\b\b\b\b\b");
-        printf("testing %3u", j);
-        fflush(stdout);
+        out_test_testing(j);
         if (compare_regions(bufa, bufb, count)) {
             return -1;
         }
     }
-    printf("\b\b\b\b\b\b\b\b\b\b\b           \b\b\b\b\b\b\b\b\b\b\b");
-    fflush(stdout);
+    out_test_end();
     return 0;
 }
 
@@ -356,14 +317,11 @@ int test_walkbits1_comparison(ulv *bufa, ulv *bufb, size_t count) {
     unsigned int j;
     size_t i;
 
-    printf("           ");
-    fflush(stdout);
+    out_test_start();
     for (j = 0; j < UL_LEN * 2; j++) {
-        printf("\b\b\b\b\b\b\b\b\b\b\b");
         p1 = (ulv *) bufa;
         p2 = (ulv *) bufb;
-        printf("setting %3u", j);
-        fflush(stdout);
+        out_test_setting(j);
         for (i = 0; i < count; i++) {
             if (j < UL_LEN) { /* Walk it up. */
                 *p1++ = *p2++ = UL_ONEBITS ^ (ONE << j);
@@ -371,15 +329,12 @@ int test_walkbits1_comparison(ulv *bufa, ulv *bufb, size_t count) {
                 *p1++ = *p2++ = UL_ONEBITS ^ (ONE << (UL_LEN * 2 - j - 1));
             }
         }
-        printf("\b\b\b\b\b\b\b\b\b\b\b");
-        printf("testing %3u", j);
-        fflush(stdout);
+        out_test_testing(j);
         if (compare_regions(bufa, bufb, count)) {
             return -1;
         }
     }
-    printf("\b\b\b\b\b\b\b\b\b\b\b           \b\b\b\b\b\b\b\b\b\b\b");
-    fflush(stdout);
+    out_test_end();
     return 0;
 }
 
@@ -389,14 +344,11 @@ int test_bitspread_comparison(ulv *bufa, ulv *bufb, size_t count) {
     unsigned int j;
     size_t i;
 
-    printf("           ");
-    fflush(stdout);
+    out_test_start();
     for (j = 0; j < UL_LEN * 2; j++) {
-        printf("\b\b\b\b\b\b\b\b\b\b\b");
         p1 = (ulv *) bufa;
         p2 = (ulv *) bufb;
-        printf("setting %3u", j);
-        fflush(stdout);
+        out_test_setting(j);
         for (i = 0; i < count; i++) {
             if (j < UL_LEN) { /* Walk it up. */
                 *p1++ = *p2++ = (i % 2 == 0)
@@ -410,15 +362,12 @@ int test_bitspread_comparison(ulv *bufa, ulv *bufb, size_t count) {
                                     | (ONE << (UL_LEN * 2 + 1 - j)));
             }
         }
-        printf("\b\b\b\b\b\b\b\b\b\b\b");
-        printf("testing %3u", j);
-        fflush(stdout);
+        out_test_testing(j);
         if (compare_regions(bufa, bufb, count)) {
             return -1;
         }
     }
-    printf("\b\b\b\b\b\b\b\b\b\b\b           \b\b\b\b\b\b\b\b\b\b\b");
-    fflush(stdout);
+    out_test_end();
     return 0;
 }
 
@@ -429,30 +378,25 @@ int test_bitflip_comparison(ulv *bufa, ulv *bufb, size_t count) {
     ul q;
     size_t i;
 
-    printf("           ");
-    fflush(stdout);
+    out_test_start();
     for (k = 0; k < UL_LEN; k++) {
         q = ONE << k;
         for (j = 0; j < 8; j++) {
-            printf("\b\b\b\b\b\b\b\b\b\b\b");
             q = ~q;
-            printf("setting %3u", k * 8 + j);
-            fflush(stdout);
+            out_test_setting(k * 8 + j);
             p1 = (ulv *) bufa;
             p2 = (ulv *) bufb;
             for (i = 0; i < count; i++) {
                 *p1++ = *p2++ = (i % 2) == 0 ? q : ~q;
             }
-            printf("\b\b\b\b\b\b\b\b\b\b\b");
-            printf("testing %3u", k * 8 + j);
+            out_test_testing(k * 8 + j);
             fflush(stdout);
             if (compare_regions(bufa, bufb, count)) {
                 return -1;
             }
         }
     }
-    printf("\b\b\b\b\b\b\b\b\b\b\b           \b\b\b\b\b\b\b\b\b\b\b");
-    fflush(stdout);
+    out_test_end();
     return 0;
 }
 
@@ -461,11 +405,10 @@ int test_8bit_wide_random(ulv* bufa, ulv* bufb, size_t count) {
     u8v *p1, *t;
     ulv *p2;
     int attempt;
-    unsigned int b, j = 0;
+    unsigned int b;
     size_t i;
 
-    putchar(' ');
-    fflush(stdout);
+    out_wheel_start();
     for (attempt = 0; attempt < 2;  attempt++) {
         if (attempt & 1) {
             p1 = (u8v *) bufa;
@@ -480,18 +423,13 @@ int test_8bit_wide_random(ulv* bufa, ulv* bufb, size_t count) {
             for (b=0; b < UL_LEN/8; b++) {
                 *p1++ = *t++;
             }
-            if (!(i % PROGRESSOFTEN)) {
-                putchar('\b');
-                putchar(progress[++j % PROGRESSLEN]);
-                fflush(stdout);
-            }
+            out_wheel_advance(i);
         }
         if (compare_regions(bufa, bufb, count)) {
             return -1;
         }
     }
-    printf("\b \b");
-    fflush(stdout);
+    out_wheel_end();
     return 0;
 }
 
@@ -499,11 +437,10 @@ int test_16bit_wide_random(ulv* bufa, ulv* bufb, size_t count) {
     u16v *p1, *t;
     ulv *p2;
     int attempt;
-    unsigned int b, j = 0;
+    unsigned int b;
     size_t i;
 
-    putchar( ' ' );
-    fflush( stdout );
+    out_wheel_start();
     for (attempt = 0; attempt < 2; attempt++) {
         if (attempt & 1) {
             p1 = (u16v *) bufa;
@@ -518,18 +455,13 @@ int test_16bit_wide_random(ulv* bufa, ulv* bufb, size_t count) {
             for (b = 0; b < UL_LEN/16; b++) {
                 *p1++ = *t++;
             }
-            if (!(i % PROGRESSOFTEN)) {
-                putchar('\b');
-                putchar(progress[++j % PROGRESSLEN]);
-                fflush(stdout);
-            }
+            out_wheel_advance(i);
         }
         if (compare_regions(bufa, bufb, count)) {
             return -1;
         }
     }
-    printf("\b \b");
-    fflush(stdout);
+    out_wheel_end();
     return 0;
 }
 #endif

--- a/tests.h
+++ b/tests.h
@@ -9,7 +9,7 @@
  * See the file COPYING for details.
  *
  * This file contains the declarations for the functions for the actual tests,
- * called from the main routine in memtester.c.  See other comments in that 
+ * called from the main routine in memtester.c.  See other comments in that
  * file.
  *
  */
@@ -32,8 +32,7 @@ int test_walkbits0_comparison(unsigned long volatile *bufa, unsigned long volati
 int test_walkbits1_comparison(unsigned long volatile *bufa, unsigned long volatile *bufb, size_t count);
 int test_bitspread_comparison(unsigned long volatile *bufa, unsigned long volatile *bufb, size_t count);
 int test_bitflip_comparison(unsigned long volatile *bufa, unsigned long volatile *bufb, size_t count);
-#ifdef TEST_NARROW_WRITES    
+#ifdef TEST_NARROW_WRITES
 int test_8bit_wide_random(unsigned long volatile *bufa, unsigned long volatile *bufb, size_t count);
 int test_16bit_wide_random(unsigned long volatile *bufa, unsigned long volatile *bufb, size_t count);
 #endif
-


### PR DESCRIPTION
Hi,

Here's a patch to automatically disable progress when stdout is not a tty. 
It is useful to save the memtester output to a file for later parsing (memtester 10 1 >logfile) or otherwise process it in a pipe without all those backspace characters. 

I'm also sending a trivial cleanup patch to remove trailing whitespace.
