### PR TITLE
bugfix quiet option : no argument needed

### DIFF
--- a/memtester.c
+++ b/memtester.c
@@ -153,7 +153,7 @@ int main(int argc, char **argv) {
         printf("using testmask 0x%lx\n", testmask);
     }
 
-    while ((opt = getopt(argc, argv, "p:d:q:u")) != -1) {
+    while ((opt = getopt(argc, argv, "p:d:qu")) != -1) {
         switch (opt) {
             case 'p':
                 errno = 0;


### PR DESCRIPTION
With the previous optstring, the `-q` option requires an argument and thus takes over the next argument (which is logically the memsize).

Thanks for this branch btw, very helpful